### PR TITLE
Change a string literal in response headers

### DIFF
--- a/src/main/java/com/notnoop/mpns/MpnsResponse.java
+++ b/src/main/java/com/notnoop/mpns/MpnsResponse.java
@@ -43,7 +43,7 @@ public enum MpnsResponse {
      * The notification request was accepted and queued for delivery. However,
      * the device is temporarily disconnected.
      */
-    QUEUED(200, "Received", "Temporarily Disconnected", "Active", true, false),
+    QUEUED(200, "Received", "TempDisconnected", "Active", true, false),
 
     /**
      * Queue overflow. The web service should re-send the notification later.


### PR DESCRIPTION
reference: http://msdn.microsoft.com/en-us/library/windowsphone/develop/ff941100%28v=vs.105%29.aspx#BKMK_PushNotificationServiceResponseCodes
I did some testing. After inspecting the actual response, it turned out that there is no space in the word 'TempDisconnected' unlike the one in the above document.
